### PR TITLE
add Hackropole platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The chals below are listed with recommended ones first, then the rest in alphabe
 - [ExploitExercises Main Sequence](https://exploit.education/main-sequence/) <img src="https://img.shields.io/badge/style-offline-lightgrey.svg"> <img src="https://img.shields.io/badge/scoring-no-lightgrey.svg">
 - [ExploitExercises Nebula](https://exploit.education/nebula/) <img src="https://img.shields.io/badge/difficulty-beginner-green.svg"> <img src="https://img.shields.io/badge/style-offline-lightgrey.svg"> <img src="https://img.shields.io/badge/scoring-no-lightgrey.svg">
 - [Flagyard](https://flagyard.com/)
+- [Hackropole](https://hackropole.fr/en/) <img src="https://img.shields.io/badge/style-offline-lightgrey.svg"> <img src="https://img.shields.io/badge/scoring-no-lightgrey.svg">
 - [HackTheBox](https://www.hackthebox.com)
 - [HackThisSite](https://www.hackthissite.org/)
 - [HellBound Hackers](https://www.hellboundhackers.org/)


### PR DESCRIPTION
Thank you for this awesome wargame list!

It might be interesting to add Hackropole : a platform to archive the challenges of the France Cybersecurity Challenge, an annual jeopardy-style CTF organized to select the French team for the European Cybersecurity Challenge. It lists over 400 challenges of increasing difficulty from the 2019 to 2024 editions. Challenges can be replayed by anyone, with or without an account.

